### PR TITLE
4: Refactor how Java 14 is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,45 +6,19 @@ This project contains a maven project object model file (POM file) for use by al
 
 The parent pom manages the following dependency version in the dependencyManagement section:
 
-- Secure Banking artifiacts via the import of the securebanking-bom's pom file
 - Spring Boot artifacts via the import of the spring-boot bom file
 - Other 3rd party dependencies
 - Test depenencies
 
 ## Defines the Java version for the project
 
-The parent pom specifics the version of java used by the maven-complier-plugin, and also the compiler source version and target versions. 
+The parent pom uses the `pluginManagement` section of the pom to specify the configuration for the `maven-compiler-plugin`. Via this mechanism child projects will inherit those settings. For this reason it is important to have your development machine set up to be using a JDK version that matches what is defined in this plugin configuration. Currently this is Java 14.
 
-
-### maven-compiler-plugin configuration ** Important **
-In order to ensure that the project compiles nicely on all developer workstations the maven-compiler-plugin specifies the location of the javac compiler to use. This is simpler than configuring all workspaces etc to use the correct compiler version. To configure the project to use a specific javac compiler on your system you need to define a property in your maven settings.xml file. It should look something like this;
-
-```
-<settings>
-  [...]
-  <profiles>
-    [...]
-    <profile>
-      <id>compiler</id>
-        <properties>
-          <JAVA_1_14_HOME>C:\Program Files\Java\j2sdk1.4.2_09</JAVA_1_14_HOME>
-        </properties>
-    </profile>
-  </profiles>
-  [...]
-  <activeProfiles>
-    <activeProfile>compiler</activeProfile>
-  </activeProfiles>
-</settings>
-
-```
-
-For further information see [here]([https://maven.apache.org/plugins/maven-compiler-plugin/examples/compile-using-different-jdk.html)
+The ForgeRock development team use OpenJDK 14. 
 
 ## Distribution Management 
 
-The parent pom specifies the repositories into which artifacts should be built. Child Open Banking projects should
-not need to override these settings 
+The parent pom specifies the repositories into which artifacts should be built. Child Open Banking projects should not need to override these settings 
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,10 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <maven.compiler.target>14</maven.compiler.target>
-        <maven.compiler.source>14</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
+        <java.version>14</java.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <spring-boot.version>2.3.5.RELEASE</spring-boot.version>
         <spring-cloud.version>2.2.6.RELEASE</spring-cloud.version>
         <logstash.version>6.4</logstash.version>
@@ -62,16 +61,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Secure Banking dependencies -->
-            <dependency>
-                <groupId>com.forgerock.securebanking</groupId>
-                <artifactId>securebanking-bom</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- Spring Boot Dependencies -->
-            <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -141,12 +130,11 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>${maven-compiler-plugin.version}</version>
                     <configuration>
+                        <release>${java.version}</release>
                         <verbose>true</verbose>
                         <fork>true</fork>
-                        <executable>${JAVA_1_14_HOME}/bin/javac</executable>
-                        <compilerVersion>14</compilerVersion>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
After testing, and also getting JAVA_HOME set to the right JDK in
/etc/profile.d/jdk.sh (on Ubuntu 20.04) then I could be much more hands
off with regard to specifying the java version. I no longer need to have
the maven-complier-plugin specify which javac compiler to use!

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4