### PR TITLE
Places license at top of file using JAVADOC_STYLE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
                             <email>obst@forgerock.com</email>
                         </properties>
                         <mapping>
-                            <java>JAVAPKG_STYLE</java>
+                            <java>JAVADOC_STYLE</java>
                         </mapping>
                     </configuration>
                     <executions>


### PR DESCRIPTION
The JAVADOC_STYLE is more familiar and I can see no benefit to having
the license placed after the package declaration in the .java file.

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4