### PR TITLE
4: Publish SNAPSHOT release on merge to master

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -1,8 +1,6 @@
 name: pull-request
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -18,13 +16,10 @@ jobs:
           architecture: x64
 
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
-
-      - name: Check Copyright
-        run: mvn license:check
 
       - name: Build and Test
         run: mvn clean package

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -1,0 +1,48 @@
+name: merge-master
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Check PR integrity
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '14'
+          architecture: x64
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
+
+      - name: Get version
+          run: |
+            VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )
+            echo "::set-output name=version::$VERSION"
+          id: get_version
+
+      - name: Set up snapshot forgerock maven repository
+          if: contains($VERSION, 'SNAPSHOT')
+          uses: actions/setup-java@v1
+          with: # running setup-java and overwrites the settings.xml
+            java-version: "14"
+            architecture: x64
+            server-id: maven.forgerock.org-community-snapshots # Value of the distributionManagement/repository/id field of the pom.xml
+            server-username: MAVEN_REPO_USERNAME # env variable for username in deploy
+            server-password: MAVEN_REPO_TOKEN # env variable for token in deploy
+
+      - name: Release package
+        run: mvn -B deploy
+        env:
+          MAVEN_REPO_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
+          MAVEN_REPO_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}
+
+      - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}


### PR DESCRIPTION
Separated the action out. Now have merge-master action and check-build.
Merge-master action will publish a SNAPSHOT release when merging to
master.

Full releases must be managed locally to perform the release and then
when a release is created in github the release artifact will be
pubished.

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4