### PR TITLE
4: Publish SNAPSHOT release on merge to master

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -23,23 +23,30 @@ jobs:
 
       - name: Get version
         run: |
-          VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )
-          echo "::set-env name=VERSION::$VERSION"
+          echo "VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )" >> $GITHUB_ENV
           echo "Version is $VERSION"
         id: get_version
 
       - name: Set up snapshot forgerock maven repository
-          if: contains("$VERSION", 'SNAPSHOT')
-          uses: actions/setup-java@v1
-          with: # running setup-java and overwrites the settings.xml
-            java-version: "14"
-            architecture: x64
-            server-id: maven.forgerock.org-community-snapshots # Value of the distributionManagement/repository/id field of the pom.xml
-            server-username: MAVEN_REPO_USERNAME # env variable for username in deploy
-            server-password: MAVEN_REPO_TOKEN # env variable for token in deploy
+        if: contains( env.VERSION, 'SNAPSHOT')
+        uses: actions/setup-java@v1
+        with: # running setup-java and overwrites the settings.xml
+          java-version: "14"
+          architecture: x64
+          server-id: maven.forgerock.org-community-snapshots # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: MAVEN_REPO_USERNAME # env variable for username in deploy
+          server-password: MAVEN_REPO_TOKEN # env variable for token in deploy
 
-      - name: Release package
+      - name: Release snapshot package
+        if: contains(env.VERSION, 'SNAPSHOT')
         run: mvn -B deploy
+        env:
+          MAVEN_REPO_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
+          MAVEN_REPO_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}
+
+      - name: Check Integrity
+        if: "!contains(env.VERSION, 'SNAPSHOT')"
+        run: mvn -B verify
         env:
           MAVEN_REPO_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
           MAVEN_REPO_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
                 <artifactId>spring-cloud-starter-zipkin</artifactId>
                 <version>${spring-cloud.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-config</artifactId>
@@ -239,7 +240,6 @@
                     </configuration>
                 </plugin>
 
-
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
@@ -264,7 +264,6 @@
                         </execution>
                     </executions>
                 </plugin>
-
 
                 <plugin>
                     <groupId>com.mycila</groupId>
@@ -302,9 +301,8 @@
             </plugins>
         </pluginManagement>
 
-
-
         <plugins>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -315,20 +313,22 @@
                 <artifactId>license-maven-plugin</artifactId>
             </plugin>
 
-
         </plugins>
     </build>
 
     <distributionManagement>
+
         <repository>
             <id>maven.forgerock.org-community</id>
             <name>maven.forgerock.org-releases</name>
             <url>https://maven.forgerock.org:443/repo/community</url>
         </repository>
+
         <snapshotRepository>
             <id>maven.forgerock.org-community-snapshots</id>
             <name>maven.forgerock.org-snapshots</name>
             <url>https://maven.forgerock.org:443/repo/community</url>
         </snapshotRepository>
+
     </distributionManagement>
 </project>


### PR DESCRIPTION
Separated the action out. Now have merge-master action and check-build.
Merge-master action will publish a SNAPSHOT release when merging to
master.

Full releases must be managed locally to perform the release and then
when a release is created in github the release artifact will be
pubished.

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4