### PR TITLE
4: Update snapshots and remove bad spring-boot-starter-test

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -22,7 +22,7 @@ jobs:
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
 
       - name: Build and Test
-        run: mvn clean package
+        run: mvn -U clean package
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -39,14 +39,14 @@ jobs:
 
       - name: Release snapshot package
         if: contains(env.VERSION, 'SNAPSHOT')
-        run: mvn -B deploy
+        run: mvn -U -B deploy
         env:
           MAVEN_REPO_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
           MAVEN_REPO_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}
 
       - name: Check Integrity
         if: "!contains(env.VERSION, 'SNAPSHOT')"
-        run: mvn -B verify
+        run: mvn -U -B verify
         env:
           MAVEN_REPO_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
           MAVEN_REPO_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -104,19 +104,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-test</artifactId>
-                <scope>test</scope>
-                <!-- ensure junit 4 tests aren't created by mistake -->
-                <exclusions>
-                    <exclusion>
-                        <groupId>junit</groupId>
-                        <artifactId>junit</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <!-- Spring Cloud Dependencies -->
             <dependency>
                 <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
In trying to exclude junit4 from spring-boot-starter-test I was
overriding the import from the spring-boot-dependencies bom and hiding
the version!

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4