### PR TITLE
27: Add dependencies for aspsp-simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,149 @@
+# Git Changelog Maven plugin changelog
+Changelog of Git Changelog Maven plugin.
+## Unreleased
+### GitHub [#1](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/1) 4: Use current version of spring
+[4a3c414a922e89c](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/4a3c414a922e89c) Jamie Bowen *2020-11-19 13:20:35*
+4: Use current version of spring (#1)
+
+Part of https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+### GitHub [#10](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/10) 4: Publish SNAPSHOT release on merge to master
+[49242001cf477e0](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/49242001cf477e0) Jamie Bowen *2020-12-10 13:59:51*
+4: Publish SNAPSHOT release on merge to master (#10)
+
+Separated the action out. Now have merge-master action and check-build.
+Merge-master action will publish a SNAPSHOT release when merging to
+master.
+
+Full releases must be managed locally to perform the release and then
+when a release is created in github the release artifact will be
+pubished.
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+### GitHub [#11](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/11) 4: Publish SNAPSHOT release on merge to master
+[b913a04d8498bc3](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/b913a04d8498bc3) Jamie Bowen *2020-12-10 16:20:54*
+4: Publish SNAPSHOT release on merge to master (#11)
+
+Separated the action out. Now have merge-master action and check-build.
+Merge-master action will publish a SNAPSHOT release when merging to
+master.
+
+Full releases must be managed locally to perform the release and then
+when a release is created in github the release artifact will be
+pubished.
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+### GitHub [#12](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/12) 4: Publish SNAPSHOT release on merge to master
+[4611923c265cf37](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/4611923c265cf37) Jamie Bowen *2020-12-11 14:10:58*
+4: Publish SNAPSHOT release on merge to master (#9) (#12)
+
+Separated the action out. Now have merge-master action and check-build.
+Merge-master action will publish a SNAPSHOT release when merging to
+master.
+
+Full releases must be managed locally to perform the release and then
+when a release is created in github the release artifact will be
+pubished.
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+### GitHub [#13](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/13) 4: Update snapshots and remove bad spring-boot-starter-test
+[ebc30582019ebb5](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/ebc30582019ebb5) Jamie Bowen *2020-12-11 15:50:58*
+4: Update snapshots and remove bad spring-boot-starter-test (#13)
+
+In trying to exclude junit4 from spring-boot-starter-test I was
+overriding the import from the spring-boot-dependencies bom and hiding
+the version!
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+### GitHub [#2](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/2) 4: Use secure banking BOM and spring BOM
+[989bdb467d4f87b](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/989bdb467d4f87b) Jamie Bowen *2020-11-27 17:22:21*
+4: Use secure banking BOM and spring BOM (#2)
+
+Also adds a read me and some more 3rd party dependencies
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+### GitHub [#3](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/3) 4: Refactor how Java 14 is specified
+[dfd4913232b2ad4](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/dfd4913232b2ad4) Jamie Bowen *2020-11-30 16:24:20*
+4: Refactor how Java 14 is specified (#3)
+
+After testing, and also getting JAVA_HOME set to the right JDK in
+/etc/profile.d/jdk.sh (on Ubuntu 20.04) then I could be much more hands
+off with regard to specifying the java version. I no longer need to have
+the maven-complier-plugin specify which javac compiler to use!
+
+Removed the import of the securbanking-bom
+
+After discussion with the team it was felt that the best approach would
+be to not include all versions in an imported parent bom. This leads to
+circular dependencies when you update the bom with latest versions,
+update the parent pom to use the latest bom, then need to update all the
+child projects that use the parent... not good.
+
+So instead we will use a bom file in the securebanking-commons library
+that may be imported into clients such as the securebanking-rcs or
+securebanking-openbanking-aspsp projects.
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+### GitHub [#4](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/4) Create check build github action
+[f05aa038c63df9f](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/f05aa038c63df9f) Jamie Bowen *2020-12-01 10:54:09*
+Create check build github action (#4)
+
+Checks the build integrity on creation of a pr or a push to master. i.e.
+when a PR is create, and when code is merged into master
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+### GitHub [#5](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/5) 12: Manage securebanking-common dependencies
+[38e6fa427151584](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/38e6fa427151584) Jamie Bowen *2020-12-02 14:03:12*
+12: Manage securebanking-common dependencies (#5)
+
+While addressing PR comments for https://github.com/SecureBankingAcceleratorToolkit/securebanking-common/pull/1
+I have moved some of the dependencies that were being managed in
+securebanking-common-openbanking-uk-datamodel into the parent pom
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/12
+### GitHub [#6](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/6) Runs a license header check when building
+[a8815ea89e8dde9](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/a8815ea89e8dde9) Jamie Bowen *2020-12-09 10:17:48*
+Runs a license header check when building (#6)
+
+The license header check was failing in the github actions and needed
+fixing.
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+### GitHub [#7](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/7) Places license at top of file using JAVADOC_STYLE
+[8400cec9f2867c4](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/8400cec9f2867c4) Jamie Bowen *2020-12-09 14:21:52*
+Places license at top of file using JAVADOC_STYLE (#7)
+
+The JAVADOC_STYLE is more familiar and I can see no benefit to having
+the license placed after the package declaration in the .java file.
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+### GitHub [#8](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/8) 4: Publish to artifactory when a release is made
+[8043fd258e8bb47](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/8043fd258e8bb47) Jamie Bowen *2020-12-10 11:53:03*
+4: Publish to artifactory when a release is made (#8)
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+### GitHub [#9](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/9) 4: Publish SNAPSHOT release on merge to master
+[4611923c265cf37](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/4611923c265cf37) Jamie Bowen *2020-12-11 14:10:58*
+4: Publish SNAPSHOT release on merge to master (#9) (#12)
+
+Separated the action out. Now have merge-master action and check-build.
+Merge-master action will publish a SNAPSHOT release when merging to
+master.
+
+Full releases must be managed locally to perform the release and then
+when a release is created in github the release artifact will be
+pubished.
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+[a4134d970650a0d](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/a4134d970650a0d) Jamie Bowen *2020-12-10 13:43:58*
+4: Publish SNAPSHOT release on merge to master (#9)
+
+Separated the action out. Now have merge-master action and check-build.
+Merge-master action will publish a SNAPSHOT release when merging to
+master.
+
+Full releases must be managed locally to perform the release and then
+when a release is created in github the release artifact will be
+pubished.
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
+[29dd01620d0a457](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/29dd01620d0a457) JamieB *2020-11-19 09:45:19*
+Initial commit

--- a/pom.xml
+++ b/pom.xml
@@ -68,28 +68,44 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>14</java.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+
         <spring-boot.version>2.3.5.RELEASE</spring-boot.version>
         <spring-cloud.version>2.2.6.RELEASE</spring-cloud.version>
-        <logstash.version>6.4</logstash.version>
-        <jmockdata.version>4.2.0</jmockdata.version>
-        <lombok.version>1.18.16</lombok.version>
-        <guava.version>30.0-jre</guava.version>
-        <nimbus-jose.version>9.1.3</nimbus-jose.version>
-        <assertj.version>3.18.1</assertj.version>
-        <junit-jupiter.version>5.7.0</junit-jupiter.version>
-        <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
-        <!-- TODO: Matt review these versions.
-        I remember him trying to update some versions and deciding new versions didn't work with the OB swagger
-        generated files??
-        -->
-        <jersey.version>2.30</jersey.version>
-        <jackson-databind.version>2.9.9</jackson-databind.version>
-        <springfox-version>2.9.2</springfox-version>
+        <validation-api.version>2.0.1.Final</validation-api.version>
         <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
         <javax-el.version>3.0.1-b12</javax-el.version>
+        <springfox.version>3.0.0</springfox.version>
+        <jaxb-api.version>2.3.1</jaxb-api.version>
+        <joda-time.version>2.10.8</joda-time.version>
+        <jackson-joda.version>2.9.7</jackson-joda.version>
+        <jackson.version>2.11.3</jackson.version>
+        <jersey.version>2.30</jersey.version>
+        <guava.version>30.0-jre</guava.version>
+        <lombok.version>1.18.16</lombok.version>
+        <bouncycastle.version>1.67</bouncycastle.version>
+        <model-mapper.version>2.3.8</model-mapper.version>
+        <nimbus-jose.version>9.1.3</nimbus-jose.version>
+        <logstash.version>6.4</logstash.version>
+
+        <junit-jupiter.version>5.7.0</junit-jupiter.version>
+        <assertj.version>3.18.1</assertj.version>
+        <mockito.version>3.5.15</mockito.version>
+        <flapdoodle-mongo.version>2.2.0</flapdoodle-mongo.version>
+        <!-- TODO - Can we get rid of this? -->
+        <jmockdata.version>4.2.0</jmockdata.version>
+
+        <!-- Plugin versions -->
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
+        <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
+        <spring-boot-maven-plugin.version>2.3.7.RELEASE</spring-boot-maven-plugin.version>
+        <build-helper-plugin.version>3.2.0</build-helper-plugin.version>
         <mycila-license-maven-plugin.version>4.0.rc1</mycila-license-maven-plugin.version>
-        <build-helper.version>3.2.0</build-helper.version>
+        <openapi-generator.version>4.3.1</openapi-generator.version>
+        <git-changelog-maven-plugin.version>1.63</git-changelog-maven-plugin.version>
+        <jib-maven-plugin.version>2.5.2</jib-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -137,9 +153,32 @@
             </dependency>
 
             <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${validation-api.version}</version>
+            </dependency>
+
+            <!-- Jackson -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-joda</artifactId>
+                <version>${jackson-joda.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.10.8</version>
+                <version>${joda-time.version}</version>
             </dependency>
 
             <dependency>
@@ -151,27 +190,42 @@
             </dependency>
 
             <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>${lombok.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.modelmapper</groupId>
+                <artifactId>modelmapper</artifactId>
+                <version>${model-mapper.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.springfox</groupId>
                 <artifactId>springfox-swagger2</artifactId>
-                <version>${springfox-version}</version>
+                <version>${springfox.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>io.springfox</groupId>
                 <artifactId>springfox-swagger-ui</artifactId>
-                <version>${springfox-version}</version>
+                <version>${springfox.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.springfox</groupId>
+                <artifactId>springfox-boot-starter</artifactId>
+                <version>${springfox.version}</version>
             </dependency>
 
             <!-- 3rd Party Test dependencies -->
@@ -198,6 +252,13 @@
             </dependency>
 
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${hibernate-validator.version}</version>
@@ -208,6 +269,13 @@
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
                 <version>${javax-el.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>de.flapdoodle.embed</groupId>
+                <artifactId>de.flapdoodle.embed.mongo</artifactId>
+                <version>${flapdoodle-mongo.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -234,9 +302,50 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven-enforcer-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>high-severity-errors</id>
+                            <!-- Important checks that fail the build if any of them are violated -->
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <phase>validate</phase>
+                            <configuration>
+                                <rules>
+                                    <DependencyConvergence />
+                                    <bannedDependencies>
+                                        <searchTransitive>true</searchTransitive>
+                                        <excludes>
+                                            <!-- exclude junit 4 -->
+                                            <exclude>junit:junit</exclude>
+                                        </excludes>
+                                    </bannedDependencies>
+                                </rules>
+                                <failFast>true</failFast>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>${build-helper.version}</version>
+                    <version>${build-helper-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>timestamp-property</id>
@@ -285,10 +394,33 @@
                         </execution>
                     </executions>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot-maven-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.openapitools</groupId>
+                    <artifactId>openapi-generator-maven-plugin</artifactId>
+                    <version>${openapi-generator.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>com.google.cloud.tools</groupId>
+                    <artifactId>jib-maven-plugin</artifactId>
+                    <version>${jib-maven-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -298,6 +430,44 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>se.bjurr.gitchangelog</groupId>
+                <artifactId>git-changelog-maven-plugin</artifactId>
+                <version>${git-changelog-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>changelog</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>git-changelog</goal>
+                        </goals>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <noIssueName>test</noIssueName>
+                            <templateContent>
+                                <![CDATA[
+# Git Changelog Maven plugin changelog
+Changelog of Git Changelog Maven plugin.
+{{#tags}}
+## {{name}}
+ {{#issues}}
+  {{#hasLink}}
+### {{name}} [{{issue}}]({{link}}) {{title}}
+  {{/hasLink}}
+  {{#commits}}
+[{{hash}}](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/{{hash}}) {{authorName}} *{{commitTime}}*
+{{{message}}}
+  {{/commits}}
+ {{/issues}}
+{{/tags}}
+]]>
+                            </templateContent>
+                            <file>CHANGELOG.md</file>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
This PR introduces the following:

- The required dependencies for securebanking-openbanking-aspsp-simulator
- Strips out JUnit 4 dependencies and enforces it with the maven enforcer plugin
- Grouped dependency versions by type

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/27