### PR TITLE
8: Add reproducible builds maven plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAccelerat
 - Ensured JUnit 4 isn't being pulled in by spring-boot-starter-test
 
 Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/27
+### GitHub [#17](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/17) 4: Remove some warnings from child builds
+[66e32480369b96a](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/66e32480369b96a) Jamie Bowen *2020-12-16 11:22:50*
+4: Remove some warnings from child builds (#17)
+
+Specify version of git-commit-id-plugin
+Specify locale for build-helper-plugin
+
+Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/4
 ### GitHub [#2](https://github.com/SecureBankingAcceleratorToolkit/securebanking-parent/pull/2) 4: Use secure banking BOM and spring BOM
 [989bdb467d4f87b](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/989bdb467d4f87b) Jamie Bowen *2020-11-27 17:22:21*
 4: Use secure banking BOM and spring BOM (#2)

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
         <git-changelog-maven-plugin.version>1.63</git-changelog-maven-plugin.version>
         <jib-maven-plugin.version>2.5.2</jib-maven-plugin.version>
         <git-commit-id-plugin.version>4.0.3</git-commit-id-plugin.version>
+        <reproducible-build-maven-plugin.version>0.11</reproducible-build-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -433,10 +434,17 @@
                     <artifactId>jib-maven-plugin</artifactId>
                     <version>${jib-maven-plugin.version}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
                     <version>${git-commit-id-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>io.github.zlika</groupId>
+                    <artifactId>reproducible-build-maven-plugin</artifactId>
+                    <version>${reproducible-build-maven-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Added reproducible-build-maven-plugin to enable jib to build reproducible images

Docs here: https://github.com/GoogleContainerTools/jib/tree/master/examples/multi-module

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/8