### PR TITLE
add _infra to the license exclude pom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -419,6 +419,8 @@
                                     <exclude>src/test/resources/**</exclude>
                                     <exclude>src/main/resources/**</exclude>
                                     <exclude>_infra/**</exclude>
+                                    <exclude>Dockerfile</exclude>
+                                    <exclude>Makefile</exclude>
                                 </excludes>
                             </licenseSet>
                         </licenseSets>

--- a/pom.xml
+++ b/pom.xml
@@ -418,6 +418,7 @@
                                     <exclude>**/README</exclude>
                                     <exclude>src/test/resources/**</exclude>
                                     <exclude>src/main/resources/**</exclude>
+                                    <exclude>_infra/**</exclude>
                                 </excludes>
                             </licenseSet>
                         </licenseSets>


### PR DESCRIPTION
each microservice will have a `_infra` folder containing the helm chart. need to add the license exclusion from this folder