### PR TITLE
OPENIG-10328 Bump SAPIG versions for dev after release of SAPIG 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.forgerock.sapi.gateway</groupId>
     <artifactId>secure-api-gateway-parent</artifactId>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>5.3.0-SNAPSHOT</version>
     <name>securebanking-parent</name>
     <packaging>pom</packaging>
     <description>A parent pom to be used by all ForgeRock Secure Api Gateway projects</description>
@@ -131,7 +131,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
 
-        <openig.version>2026.3.0-SNAPSHOT</openig.version>
+        <openig.version>2026.6.0-SNAPSHOT</openig.version>
         <spring-boot.version>3.5.8</spring-boot.version>
         <jakarta.validation-api.version>3.1.0-M1</jakarta.validation-api.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>


### PR DESCRIPTION
Post-release version bump to 5.3.0-SNAPSHOT / IG 2026.6.0-SNAPSHOT. Part of SAPIG 5.2.0 release.